### PR TITLE
Reboot: Update Select.jl for multithreaded, modern Julia

### DIFF
--- a/src/Select.jl
+++ b/src/Select.jl
@@ -227,10 +227,10 @@ end
 # Kill all tasks in "tasks" besides  a given task. Used for killing the rivals
 # of the winning waiting task.
 function select_kill_rivals(tasks, myidx)
-    @info myidx
+    #@info myidx
     for (taskidx, task) in enumerate(tasks)
         taskidx == myidx && continue
-        @info taskidx, task
+        #@info taskidx, task
         #if task.state == :waiting || task.state == :queued
             # Rival is blocked waiting for its channel; send it a message that it's
             # lost the race.
@@ -244,7 +244,7 @@ function select_kill_rivals(tasks, myidx)
         #     deleteat!(Base.Workqueue, queueidx)
         # end
     end
-    @info "done killing"
+    #@info "done killing"
 end
 function _select_block_macro(clauses)
     branches = Expr(:block)
@@ -276,22 +276,22 @@ function _select_block_macro(clauses)
                     # Listen for SelectInterrupt messages so we can shutdown
                     # if a rival's channel unblocks first.
                     try
-                        @info "Task $($i) about to lock"
+                        #@info "Task $($i) about to lock"
                         lock($wait_condition)
-                        @info "Task $($i) about to wait"
+                        #@info "Task $($i) about to wait"
                         while !$isready_func($channel_var)
-                            @info "Task $($i) waiting"
+                            #@info "Task $($i) waiting"
                             Base.check_channel_state($channel_var)
                             wait($wait_condition)  # Can be cancelled while waiting here...
                         end
                         # We got the lock, so run this task to completion.
-                        @info "Task $($i) woke: killing rivals"
+                        #@info "Task $($i) woke: killing rivals"
                         select_kill_rivals(tasks, $i)
                         event_val = $mutate_channel
-                        @info "Got event_val: $event_val"
+                        #@info "Got event_val: $event_val"
                         put!(winner_ch, ($i, event_val))
                     catch err
-                        @info "CAUGHT SelectInterrupt: $err"
+                        #@info "CAUGHT SelectInterrupt: $err"
                         if isa(err, SelectInterrupt)
                             yieldto(err.parent)  # TODO: is this still a thing we should do?
                             return

--- a/src/Select.jl
+++ b/src/Select.jl
@@ -257,7 +257,7 @@ function _select_block_macro(clauses)
             bind_variable = :($value_var = branch_val)
         end
         branch = quote
-            tasks[$i] = @async begin
+            tasks[$i] = Threads.@spawn begin
                 $channel_declaration_expr
                 try  # Listen for genuine errors to throw to the main task
                     $channel_assignment_expr

--- a/src/Select.jl
+++ b/src/Select.jl
@@ -227,10 +227,10 @@ end
 # Kill all tasks in "tasks" besides  a given task. Used for killing the rivals
 # of the winning waiting task.
 function select_kill_rivals(tasks, myidx)
-    #@info myidx
+    @info myidx
     for (taskidx, task) in enumerate(tasks)
         taskidx == myidx && continue
-        #@info taskidx, task
+        @info taskidx, task
         #if task.state == :waiting || task.state == :queued
             # Rival is blocked waiting for its channel; send it a message that it's
             # lost the race.
@@ -244,7 +244,7 @@ function select_kill_rivals(tasks, myidx)
         #     deleteat!(Base.Workqueue, queueidx)
         # end
     end
-    #@info "done killing"
+    @info "done killing"
 end
 function _select_block_macro(clauses)
     branches = Expr(:block)
@@ -276,22 +276,22 @@ function _select_block_macro(clauses)
                     # Listen for SelectInterrupt messages so we can shutdown
                     # if a rival's channel unblocks first.
                     try
-                        #@info "Task $($i) about to lock"
+                        @info "Task $($i) about to lock"
                         lock($wait_condition)
-                        #@info "Task $($i) about to wait"
+                        @info "Task $($i) about to wait"
                         while !$isready_func($channel_var)
-                            #@info "Task $($i) waiting"
+                            @info "Task $($i) waiting"
                             Base.check_channel_state($channel_var)
                             wait($wait_condition)  # Can be cancelled while waiting here...
                         end
                         # We got the lock, so run this task to completion.
-                        #@info "Task $($i) woke: killing rivals"
+                        @info "Task $($i) woke: killing rivals"
                         select_kill_rivals(tasks, $i)
                         event_val = $mutate_channel
-                        #@info "Got event_val: $event_val"
+                        @info "Got event_val: $event_val"
                         put!(winner_ch, ($i, event_val))
                     catch err
-                        #@info "CAUGHT SelectInterrupt: $err"
+                        @info "CAUGHT SelectInterrupt: $err"
                         if isa(err, SelectInterrupt)
                             yieldto(err.parent)  # TODO: is this still a thing we should do?
                             return

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,14 @@
 using Select
-using Base.Test
+using Test
+
+@testset "self-references" begin
+    ch = Channel()
+    @test Select.@select begin
+        ch <| "hi"          => "put"
+        ch |> x             => "take! |> $x"
+        @async(sleep(1))    => "timeout"
+    end == "timeout"
+end
 
 function select_block_test(t1, t2, t3, t4)
     c1 = Channel{Symbol}(1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,22 +8,22 @@ function select_block_test(t1, t2, t3, t4)
 
     put!(c3,1)
 
-    @schedule begin
+    @async begin
         sleep(t1)
         put!(c1,:a)
     end
 
-    @schedule begin
+    @async begin
         sleep(t2)
         put!(c2,1)
     end
 
-    @schedule begin
+    @async begin
         sleep(t3)
         take!(c3)
     end
 
-    task = @schedule begin
+    task = @async begin
         sleep(t4)
         :task_done
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,26 +1,6 @@
 using Select
 using Test
 
-@testset "self-references" begin
-    # Test multiple times because the deadlock was only triggered if Task 1 is run before
-    # Task 2 or Task 3. Running it multiple times will hopefully cover all the cases.
-    for _ in 1:10
-        # Test that the two clauses in `@select` can't trigger eachother (Here, the problem
-        # would be if Task 1 puts into ch, then Task 2 sees Task 1 waiting, and thinks ch is
-        # ready to take! and attempts to incorrectly proceed w/ the take!.) Instead, this should
-        # timeout, since no one else is putting or taking on `ch`.
-        ch = Channel()
-        @test @select(begin
-            ch <| "hi"          => "put"
-            # This take!(ch) should not be triggered by the put
-            ch |> x             => "take! |> $x"
-            # This wait(ch) should also not be triggered by the put
-            ch                  => "waiting on ch"
-            @async(sleep(0.3))  => "timeout"
-        end) == "timeout"
-    end
-end
-
 function select_block_test(t1, t2, t3, t4)
     c1 = Channel{Symbol}(1)
     c2 = Channel{Int}(1)
@@ -84,3 +64,23 @@ end
 @test select_nonblock_test(:take) == "Got 1 from c"
 @test select_nonblock_test(:put) == "Wrote to c2"
 @test select_nonblock_test(:default) == "Default case"
+
+@testset "self-references" begin
+    # Test multiple times because the deadlock was only triggered if Task 1 is run before
+    # Task 2 or Task 3. Running it multiple times will hopefully cover all the cases.
+    for _ in 1:10
+        # Test that the two clauses in `@select` can't trigger eachother (Here, the problem
+        # would be if Task 1 puts into ch, then Task 2 sees Task 1 waiting, and thinks ch is
+        # ready to take! and attempts to incorrectly proceed w/ the take!.) Instead, this should
+        # timeout, since no one else is putting or taking on `ch`.
+        ch = Channel()
+        @test @select(begin
+            ch <| "hi"          => "put"
+            # This take!(ch) should not be triggered by the put
+            ch |> x             => "take! |> $x"
+            # This wait(ch) should also not be triggered by the put
+            ch                  => "waiting on ch"
+            @async(sleep(0.3))  => "timeout"
+        end) == "timeout"
+    end
+end


### PR DESCRIPTION
- [x] Update to Julia 1.0 (this was written in 2015, during (i think) `v0.4`)
- [x] Update to be aware of multithreading, and still perform correctly
- [ ] Verify that this behaves correctly for all types of things you can wait on (Conditions, Channels, Tasks, Futures, ...?)